### PR TITLE
Added option to use by require() besides import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ import Drawflow from 'drawflow'
 import styleDrawflow from 'drawflow/dist/drawflow.min.css'
 ```
 
+#### Require 
+```javascript
+var Drawflow = require('drawflow')
+var styleDrawflow = require('drawflow/dist/drawflow.min.css')
+```
+
 Create the parent element of **drawflow**.
 ```html
 <div id="drawflow"></div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "drawflow",
   "version": "0.0.20",
   "description": "Simple flow library",
-  "main": "dist/index.js",
+  "main": "dist/drawflow.min.js",
   "scripts": {
     "dev": "webpack-dev-server --mode development --open --host 0.0.0.0",
     "build": "webpack --mode=production && gulp && cp src/drawflow.js dist/index.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
     library: 'Drawflow',
     libraryTarget: 'umd',
     libraryExport: 'default',
-    filename: 'drawflow.min.js'
+    filename: 'drawflow.min.js',
+    globalObject: `(typeof self !== 'undefined' ? self : this)`
   }
 };


### PR DESCRIPTION
1. This version is fully compatible with node.js as well as browser.
The past version was only usable in browser(using it on node.js was showing window not defined).Fixed that by adding globalObject in webpack config file.

2. User can now include this library using import or require whatever method he prefers.

3. import,require and browser usage - all of these will be handled by a single file- dist/drawflow.min.js so we dont need to copy the src file again in dist/index.js (you can delete the cp command from package.json)

Please make sure you build again with webpack,since i changed webpack.config.js 