### PR TITLE
'nodeSelected' and 'nodeMoved' events fired twice

### DIFF
--- a/src/drawflow.js
+++ b/src/drawflow.js
@@ -171,6 +171,7 @@ export default class Drawflow {
   }
 
   click(e) {
+  	e.preventDefault();
     if(this.editor_mode === 'fixed') {
       //return false;
        if(e.target.classList[0] === 'parent-drawflow' || e.target.classList[0] === 'drawflow') {


### PR DESCRIPTION
Hi @jerosoler,

Depending on the graph usage, people may just want to select a node (or any element) with a single click.
When we select one node and drag it a bit, each event `nodeSelected` and `nodeMoved` are called exactly once. However, when we click a node, those two events are called twice.

So I added `e.preventDefault();` to make sure the event not to propagate.

Tested it with the docs code. Now each event is called once after a click, and dragging a node still fires the events once.