### PR TITLE
Introduce 'view' editor mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Installing only a javascript library and with four lines of code.
 - Zoom in / out
 - Clear data module
 - Support modules
-- Editor mode `fixed` and `edit`
+- Editor mode `edit`, `fixed` or `view`
 - Import / Export data
 - Events
 - Mobile support
@@ -162,7 +162,7 @@ Parameter | Type | Default | Description
 `reroute_width` | Number | 6 | Width of reroute
 `line_path` | Number | 5 | Width of line
 `force_first_input` | Boolean | false | Force the first input to drop the connection on top of the node
-`editor_mode` | Text | `edit` | `edit` or `fixed` mode
+`editor_mode` | Text | `edit` | `edit` for edit, `fixed` for nodes fixed but their input fields available, `view` for view only
 `zoom` | Number | 1 | Default zoom
 `zoom_max` | Number | 1.6 | Default zoom max
 `zoom_min` | Number | 0.5 | Default zoom min

--- a/src/drawflow.js
+++ b/src/drawflow.js
@@ -186,7 +186,11 @@ export default class Drawflow {
        } else {
          return false;
        }
-
+    } else if(this.editor_mode === 'view') {
+      if(e.target.closest(".drawflow") != null || e.target.matches('.parent-drawflow')) {
+        this.ele_selected = e.target.closest(".parent-drawflow");
+        e.preventDefault();
+      }
     } else {
       this.first_click = e.target;
       this.ele_selected = e.target;
@@ -526,7 +530,7 @@ export default class Drawflow {
   contextmenu(e) {
     this.dispatch('contextmenu', e);
     e.preventDefault();
-    if(this.editor_mode === 'fixed') {
+    if(this.editor_mode === 'fixed' || this.editor_mode === 'view') {
       return false;
     }
     if(this.precanvas.getElementsByClassName("drawflow-delete").length) {
@@ -559,7 +563,7 @@ export default class Drawflow {
 
   key(e) {
     this.dispatch('keydown', e);
-    if(this.editor_mode === 'fixed') {
+    if(this.editor_mode === 'fixed' || this.editor_mode === 'view') {
       return false;
     }
     if (e.key === 'Delete' || (e.key === 'Backspace' && e.metaKey)) {


### PR DESCRIPTION
As editor_mode set to 'view' there only move canva and zoom available. 
In the 'fixed' mode nodes are fixed but input fields available.
Closes #142.