### PR TITLE
add the possibility to override the node class with multiple space separated classes

### DIFF
--- a/src/drawflow.js
+++ b/src/drawflow.js
@@ -1187,7 +1187,7 @@ export default class Drawflow {
     node.setAttribute("id", "node-"+newNodeId);
     node.classList.add("drawflow-node");
     if(classoverride != '') {
-      node.classList.add(classoverride);
+      node.classList.add(...classoverride.split(','));
     }
 
     const inputs = document.createElement('div');
@@ -1311,7 +1311,7 @@ export default class Drawflow {
     node.setAttribute("id", "node-"+dataNode.id);
     node.classList.add("drawflow-node");
     if(dataNode.class != '') {
-      node.classList.add(dataNode.class);
+      node.classList.add(...dataNode.class.split(','));
     }
 
     const inputs = document.createElement('div');

--- a/src/drawflow.js
+++ b/src/drawflow.js
@@ -1187,7 +1187,7 @@ export default class Drawflow {
     node.setAttribute("id", "node-"+newNodeId);
     node.classList.add("drawflow-node");
     if(classoverride != '') {
-      node.classList.add(...classoverride.split(','));
+      node.classList.add(...classoverride.split(' '));
     }
 
     const inputs = document.createElement('div');
@@ -1311,7 +1311,7 @@ export default class Drawflow {
     node.setAttribute("id", "node-"+dataNode.id);
     node.classList.add("drawflow-node");
     if(dataNode.class != '') {
-      node.classList.add(...dataNode.class.split(','));
+      node.classList.add(...dataNode.class.split(' '));
     }
 
     const inputs = document.createElement('div');


### PR DESCRIPTION
Small change to be able to add multiple classes to individual nodes.
It's not a breaking change, as it works for one class only as well.

It's useful when you want to have, for example, different node sizes and still be able to have an individual class for that specific node. So, you could do, for instance:

```
  case 'facebook':
      var facebook = `
        <div>
        <div class="title-box"><i class="fab fa-facebook"></i> Facebook Message</div>
        </div>
        `;
        editor.addNode('facebook', 0,  1, pos_x, pos_y, 'facebook,drawflow-small-node', {}, facebook );
```

There are many other similar use cases, where you'd like to have a standard for multiple nodes, but also something specific for that node type.

Could be done with space instead of comma (to mimic the html class attribute), or with a configurable parameter instead. 
