### PR TITLE
Fix issue where Safari attempts to select text during drag operations

### DIFF
--- a/src/drawflow.js
+++ b/src/drawflow.js
@@ -199,9 +199,6 @@ export default class Drawflow {
         this.ele_selected = e.target.closest(".drawflow_content_node").parentElement;
       }
     }
-    if (['input','output','main-path'].includes(this.ele_selected.classList[0])) {
-      e.preventDefault();
-    }
     switch (this.ele_selected.classList[0]) {
       case 'drawflow-node':
         if(this.node_selected != null) {
@@ -328,6 +325,9 @@ export default class Drawflow {
       this.pos_x_start = e.clientX;
       this.pos_y = e.clientY;
       this.pos_y_start = e.clientY;
+    }
+    if (this.drag || ['input','output','main-path'].includes(this.ele_selected.classList[0])) {
+      e.preventDefault();
     }
     this.dispatch('clickEnd', e);
   }


### PR DESCRIPTION
When I was testing this fantastic library I found that desktop Safari would attempt to do unwated text selection during drag operations. This PR resolves that issue.

![Untitled](https://user-images.githubusercontent.com/6286310/166242065-51ff9b60-0bcb-4d52-9dcb-19d9c0a0b85e.gif)

