### PR TITLE
Add the possibility to confirm a node removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Parameter | Type | Default | Description
 `zoom_last_value` | Number | 1 | Default zoom last value
 `draggable_inputs` | Boolean | true | Drag nodes on click inputs
 `useuuid` | Boolean | false | Use UUID as node ID instead of integer index. Only affect newly created nodes, do not affect imported nodes
+`removeConfirmation` | Boolean | false | If true, `nodeRemovingRequest` event is fired instead of removing the node. It allows developper to create a confirmation message and cancel the operation or confirm it with the `removeNodeId()` method
 
 ### Reroute
 Active reroute connections. Use before `start` or `import`.
@@ -292,6 +293,7 @@ Event | Return | Description
 --- | --- | ---
   `nodeCreated` | id | `id` of Node
   `nodeRemoved` | id | `id` of Node
+  `nodeRemovingRequest` | id | Only if `removeConfirmation` is set to true. It returns the `id` of Node.
   `nodeDataChanged` | id | `id` of Node df-* attributes changed.
   `nodeSelected` | id | `id` of Node
   `nodeUnselected` | true | Unselect node

--- a/src/drawflow.js
+++ b/src/drawflow.js
@@ -44,6 +44,7 @@ export default class Drawflow {
     this.zoom_min = 0.5;
     this.zoom_value = 0.1;
     this.zoom_last_value = 1;
+    this.removeConfirmation = false;
 
     // Mobile
     this.evCache = new Array();
@@ -295,6 +296,10 @@ export default class Drawflow {
         this.ele_selected.classList.add("selected");
       break;
       case 'drawflow-delete':
+        if (this.removeConfirmation) {
+          this.dispatch('nodeRemovingRequest', this.node_selected.id);
+          break;
+        }
         if(this.node_selected ) {
           this.removeNodeId(this.node_selected.id);
         }


### PR DESCRIPTION
I've added a parameter and an event to allow the user to confirm the node removal. 
With the parameter set to yes, the node is never removed by clicking on the delete button, but a specific event is fired. One can remove the node on user confirm with the existing method `removeNodeId`