### PR TITLE
Use Multiplication unicode symbol for delete

### DIFF
--- a/src/drawflow.js
+++ b/src/drawflow.js
@@ -530,7 +530,7 @@ export default class Drawflow {
     if(this.node_selected || this.connection_selected) {
       var deletebox = document.createElement('div');
       deletebox.classList.add("drawflow-delete");
-      deletebox.innerHTML = "x";
+      deletebox.innerHTML = "✕";
       if(this.node_selected) {
         this.node_selected.appendChild(deletebox);
 


### PR DESCRIPTION
This PR replaces the usage of a normal "x" text with the Unicode Character “✕” (U+2715) instead. It looks better to represent "close" or "remove". 