### PR TITLE
fixed moduleChanged notification issue

### DIFF
--- a/src/drawflow.js
+++ b/src/drawflow.js
@@ -1846,7 +1846,7 @@ export default class Drawflow {
     this.dispatch('moduleCreated', name);
   }
   changeModule(name) {
-    this.dispatch('moduleChanged', name);
+    this.dispatch('moduleChanging', name)
     this.module = name;
     this.precanvas.innerHTML = "";
     this.canvas_x = 0;
@@ -1859,6 +1859,7 @@ export default class Drawflow {
     this.zoom_last_value = 1;
     this.precanvas.style.transform = '';
     this.import(this.drawflow, false);
+    this.dispatch('moduleChanged', name);
   }
 
   removeModule(name) {


### PR DESCRIPTION
the moduleChanged notification was firing before the module had been updated on screen, which for me was causing issues about html elements not being available. If people need to know the module is changing, I have also added a moduleChanging event.